### PR TITLE
Drop flakey test list to a CSV file

### DIFF
--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -63,7 +63,7 @@ class NodeManager:
         # paths = [
         #     ["tests/test_accounting/test_workflows"],
         #     ["tests/test_workflows"],
-        #     ["tests/"],
+        #     ["tests/test_bill_pay/test_autofilling.py"],
         # ]
         #paths = json.loads(open(f"bins.json").read())
         paths = json.loads(open(f"{os.environ['TEST_DIR']}/bins.json").read())

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -63,7 +63,7 @@ class NodeManager:
         # paths = [
         #     ["tests/test_accounting/test_workflows"],
         #     ["tests/test_workflows"],
-        #     ["tests/test_bill_pay/test_autofilling.py"],
+        #     ["tests/"],
         # ]
         #paths = json.loads(open(f"bins.json").read())
         paths = json.loads(open(f"{os.environ['TEST_DIR']}/bins.json").read())


### PR DESCRIPTION
Hi! Thanks for patience; got assed by a few commitments and some setup woes.

The `retries` dict was perfect for this, we regex on the key to get module and test name, the value is the number of retries required. We can save this CSV and push to S3 for another task to assign codeowner and subsequently blame.

If you have a preferred location for an automated test for this in the repo, lmk; I tested by installing in core and running it on many tests. Tried running it on the whole suite to see if any of the filenames made it barf, but the died at 41% because of a missing config for a remote call it was trying to make (think it was to an accounting provider, ruh-roh):

```
appuser@d880a2bb28bb:/opt/app$ [] [2023-08-11 00:14:55,324] ERROR in util: Error posting diagnostic event (giving up permanently): HTTP error 401 (invalid SDK key)
[] [2023-08-11 00:14:55,326] ERROR in util: Error posting diagnostic event (giving up permanently): HTTP error 401 (invalid SDK key)
```
