### PR TITLE
Safety fix

### DIFF
--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -152,13 +152,15 @@ class LoadScopeScheduling:
             writer = csv.writer(csvfile)
             writer.writerow(['filepath', 'test', 'num_retries'])
             for entry, num_retries in self.retries.items():
-                try:
                     match = LoadScopeScheduling.RETRIES_MODULE_AND_TEST_REGEX.match(entry)
-                    filepath = match.groups()[0]
-                    test_name = match.groups()[1]
-                    writer.writerow([filepath, test_name, num_retries])
-                except IndexError:
-                    print(f"FAILURE ON FLAKES REGEX {entry}")
+                    if match is None:
+                        continue
+                    try:
+                        filepath = match.groups()[0]
+                        test_name = match.groups()[1]
+                        writer.writerow([filepath, test_name, num_retries])
+                    except IndexError:
+                        print(f"FAILURE ON FLAKES REGEX {entry}")
 
         return True
 


### PR DESCRIPTION
Last submission had a bug, wrapped in a try to prevent a badmatch, but it resulted in a different error than the one I'd anticipated. This go-round slightly delayed to test more extensively (my Docker containers was OOM-ing, took a while to configure `paths` to work locally) and doesn't kill the run. Also tested it on all the filenames instead of just the flakes I'd previously injected.

The code that logs a badmatch (I had a `print` before that `continue` to search for the test ID that returned `None` on the regex, causing the initial bug) wasn't showing up for me, but I'll investigate that as a follow-up.