### PR TITLE
don't retry flaky tests

### DIFF
--- a/src/xdist/scheduler/loadscope.py
+++ b/src/xdist/scheduler/loadscope.py
@@ -160,14 +160,14 @@ class LoadScopeScheduling:
         with open('flakes.csv', 'w') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(['filepath', 'test', 'num_retries'])
-            for entry, num_retries in self.retries.items():
+            for entry, retry_info in self.retries.items():
                     match = LoadScopeScheduling.RETRIES_MODULE_AND_TEST_REGEX.match(entry)
                     if match is None:
                         continue
                     try:
                         filepath = match.groups()[0]
                         test_name = match.groups()[1]
-                        writer.writerow([filepath, test_name, num_retries])
+                        writer.writerow([filepath, test_name, retry_info.retry_count])
                     except IndexError:
                         print(f"FAILURE ON FLAKES REGEX {entry}")
 


### PR DESCRIPTION
This fork of pytest-xdist was designed to rerun flaky tests and succeed if any one run of a test succeeded. This approach has been causing several problems:

- Flaky tests can more easily be merged into the master branch of a CI suite, because this approach increases the chance that a flaky test has a false negative on branch CI.
- Flaky tests which are rerun at the end of a CI suite never get executed, and get marked as successful even if they would always fail.

We're ripping this out for now as we look towards other mechanisms to reduce flaky test volume. 🙂 